### PR TITLE
copy: declare dependency on types

### DIFF
--- a/copy/metadata.txt
+++ b/copy/metadata.txt
@@ -1,3 +1,4 @@
 srctype = cpython
 type = module
 version = 3.3.3-2
+depends = micropython-types


### PR DESCRIPTION
I noticed during installation and use of `copy` that it requires `types` module. 

This PR simply declares it as a dependency for automatic installation.